### PR TITLE
Relocate Express error handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,17 +110,6 @@ app.use((req, res, next) => {
 
 
 
-/* ERROR HANDLER – catches everything
-   and always sends a 500 JSON payload */
-app.use((err, req, res, next) => {
-  console.error('UNCAUGHT ROUTE ERROR:', err);
-  if (res.headersSent) return next(err);
-  if (process.env.NODE_ENV === 'production') {
-    res.status(500).send('Internal Server Error');
-  } else {
-    res.status(500).json({ error: String(err) });
-  }
-});
 
 app.use(express.static(path.join(__dirname, 'public')));
 app.use('/css', express.static(path.join(__dirname, 'node_modules/bootstrap/dist/css')));
@@ -480,6 +469,18 @@ passport.deserializeUser((user, cb) => {
   cb(null, user);
 });
 
+
+/* ERROR HANDLER – catches everything
+   and always sends a 500 JSON payload */
+app.use((err, req, res, next) => {
+  console.error("UNCAUGHT ROUTE ERROR:", err);
+  if (res.headersSent) return next(err);
+  if (process.env.NODE_ENV === "production") {
+    res.status(500).send("Internal Server Error");
+  } else {
+    res.status(500).json({ error: String(err) });
+  }
+});
 
 app.listen(PORT, '0.0.0.0', () => {
   console.log(`Server running on port ${PORT}`);


### PR DESCRIPTION
## Summary
- move the error-handling middleware to after all route definitions

## Testing
- `npm test`

------
